### PR TITLE
Fix API Key Dialog Box Behavior to Prevent Auto-Close on Empty

### DIFF
--- a/components/modals/apikey-modal.tsx
+++ b/components/modals/apikey-modal.tsx
@@ -33,6 +33,16 @@ const ApiKeyModal = () => {
     }
 
     const handleSave = () => {
+         // Check API key is not null
+        if (!apiKey) {
+            toast({
+                title: "Something went wrong",
+                description: "Please Enter API Key.",
+                variant: "destructive",
+            });
+            return;
+        }
+        
         // Save API key to cookies
         document.cookie = serialize('openaiApiKey', apiKey, { path: '/' });
         toast({

--- a/components/modals/apikey-modal.tsx
+++ b/components/modals/apikey-modal.tsx
@@ -33,16 +33,16 @@ const ApiKeyModal = () => {
     }
 
     const handleSave = () => {
-         // Check API key is not null
+        // Check API key is not null
         if (!apiKey) {
             toast({
-                title: "Something went wrong",
-                description: "Please Enter API Key.",
+                title: "API Key Required",
+                description: "Please enter a valid API key to continue.",
                 variant: "destructive",
             });
             return;
         }
-        
+
         // Save API key to cookies
         document.cookie = serialize('openaiApiKey', apiKey, { path: '/' });
         toast({


### PR DESCRIPTION
This update ensures that the API key dialog box does not close when the user has not entered any input. The dialog now remains open until the user provides a valid API key, improving the user experience by preventing accidental closure.

```
 // Check API key is not null
        if (!apiKey) {
            toast({
                title: "Something went wrong",
                description: "Please Enter API Key.",
                variant: "destructive",
            });
            return;
        }
```